### PR TITLE
Fix protobuf requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     },
     install_requires=[
         "requests",
-        "protobuf",
+        "protobuf<4",
         "grpcio",
         "bdflib",
         "click",


### PR DESCRIPTION
Fixes:
- #2 

This works on my system. It appears either Protobuf 4 or 5 have a breaking change that is incompatible with `departure==1.0.1`.